### PR TITLE
'kIsWeb' অনির্দিষ্ট নাম ত্রুটি ঠিক করুন

### DIFF
--- a/lib/core/services/call_service.dart
+++ b/lib/core/services/call_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import '../../features/call/domain/repositories/call_repository.dart';
 import '../../features/call/domain/models/call_model.dart';


### PR DESCRIPTION
Add missing `kIsWeb` import to resolve "Undefined name 'kIsWeb'" errors in `call_service.dart`.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-7eea143d-dfb8-43b3-a4d1-51a7c991cd2f) · [Cursor](https://cursor.com/background-agent?bcId=bc-7eea143d-dfb8-43b3-a4d1-51a7c991cd2f)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)