### PR TITLE
Fix call feature errors and null safety

### DIFF
--- a/lib/features/call/presentation/widgets/call_manager.dart
+++ b/lib/features/call/presentation/widgets/call_manager.dart
@@ -62,16 +62,14 @@ class _CallManagerState extends State<CallManager> {
       // Listen for incoming calls
       _incomingCallsSubscription = callRepository
           .listenToIncomingCalls(currentUserId)
-          .listen((calls) {
-        if (calls.isNotEmpty && mounted) {
-          final incomingCall = calls.first;
-          
+          .listen((call) {
+        if (call != null && mounted) {
           // Only show if it's a new incoming call and still ringing
-          if (_currentIncomingCall?.callId != incomingCall.callId && 
-              incomingCall.status == CallStatus.ringing) {
-            _currentIncomingCall = incomingCall;
-            _showIncomingCallScreen(incomingCall);
-            _listenToCallStatus(incomingCall);
+          if (_currentIncomingCall?.callId != call.callId && 
+              call.status == CallStatus.ringing) {
+            _currentIncomingCall = call;
+            _showIncomingCallScreen(call);
+            _listenToCallStatus(call);
           }
         }
       });


### PR DESCRIPTION
Fix null safety violations in `CallManager` by correctly handling `Stream<CallModel?>` instead of treating it as a list.

---

[Open in Web](https://www.cursor.com/agents?id=bc-b8922ac9-638d-43f0-a413-8cbedd76c814) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b8922ac9-638d-43f0-a413-8cbedd76c814)